### PR TITLE
Correction singulier/pluriel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 NuTyX est une distribution GNU/Linux pour systèmes 32 bits (i686) et 64 bits (x86_64).
 Sa construction est basée sur la documentation en ligne disponible sur http://www.linuxfromscratch.org.
 L'objectif de NuTyX est de permettre à ses utilisateurs d'être le plus rapidement possible autonomes.
-Le nombre de paquets est volontairement limité. Les environnement graphiques sont disponible dans des projets git séparés.
+Le nombre de paquets est volontairement limité. Les environnement graphiques sont disponibles dans des projets git séparés.
 
-NuTyX utilise son propre gestionnaire de paquets "cards". Sa particularité, gérer de façon autonome 
+NuTyX utilise son propre gestionnaire de paquets "cards". Sa particularité: gérer de façon autonome 
 les dépendances de fonctionnement. Cela signifie que l'empaqueteur ne doit pas s'en soucier lors de
 la création d'un paquet. Dans 99 % des cas, seul les dépendances de compilation suffisent. Comme chaque
-paquet est compilé à partir d'un système de base, aucune dépendances superflues ne sera ajoutées lors
+paquet est compilé à partir d'un système de base, aucune dépendance superflue ne sera ajoutée lors
 de l'installation du binaire.
 
 La syntaxe d'une recette d'un paquet est très proche de celle de la distribution CRUX. Le gestionnaire
@@ -17,9 +17,9 @@ Par défaut, il y a 3 collections:
 - base qui comprend l'ensemble des paquets /ports  qui constituent un système minimal utilisable avec tous les
 outils de développement nécessaire.
 
-- console comprend tous es paquets / ports necessaire au bon fonctionnement d'un système en ligne de commande.
+- console comprend tout les paquets / ports nécessaires au bon fonctionnement d'un système en ligne de commande.
 
-- graphic comprend tous les paquets / ports necessaire au bon fonctionnement d'un environnement graphique minimaliste.
+- graphic comprend tout les paquets / ports nécessaires au bon fonctionnement d'un environnement graphique minimaliste.
 
 Ces trois collections fondamentales, dépendent l'une de l'autre dans le sens:
 


### PR DESCRIPTION
Juste pour éviter ces erreurs sur la page de présentation de la nouvelle version de la distribution.