### PR TITLE
Corrects spelling of Brasil

### DIFF
--- a/basicfs/rootfs/sbin/setup-nutyx
+++ b/basicfs/rootfs/sbin/setup-nutyx
@@ -601,7 +601,7 @@ case ${REPLY} in
 	_msgfmt pt_PT
 	echo "export LANG=pt_PT.utf-8" > ${LOCALE}
 	ln -sf ${ZONEINFO}Europe/Lisbon ${LOCALTIME};;
- "Brazil")
+ "Brasil")
 	_msgfmt pt_BR
 	ln -sf ${ZONEINFO}America/Sao_Paulo ${LOCALTIME};;	
  "română")


### PR DESCRIPTION
It seems you use always the native writing: *Brazil* is the English spelling see: https://pt.wikipedia.org/wiki/Brasil